### PR TITLE
Update nan for io.js 2.x.x compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   "gypfile": true,
   "readmeFilename": "README.md",
   "dependencies": {
-    "nan": "~1.7.0"
+    "nan": "~1.8.4"
   }
 }


### PR DESCRIPTION
Referencing iojs/io.js#1620

Note: this PR does not address the usage of deprecated nan features causing compiler warnings. This just allows installation and compilation with io.js v2.x.x