### PR TITLE
Get extended information on nodes and their parents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "udev",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Bindings to libudev",
   "main": "udev.js",
   "scripts": {

--- a/udev.cc
+++ b/udev.cc
@@ -24,6 +24,22 @@ static void PushProperties(Local<Object> obj, struct udev_device* dev) {
     }
 }
 
+static void PushSystemAttributes(Local<Object> obj, struct udev_device* dev) {
+    struct udev_list_entry* sysattrs;
+    struct udev_list_entry* entry;
+    sysattrs = udev_device_get_sysattr_list_entry(dev);
+    udev_list_entry_foreach(entry, sysattrs) {
+        const char *name, *value;
+        name = udev_list_entry_get_name(entry);
+        value = udev_device_get_sysattr_value(dev, name);
+        if (value != NULL) {
+            obj->Set(NanNew<String>(name), NanNew<String>(value));
+        } else {
+            obj->Set(NanNew<String>(name), NanNull());
+        }
+    }
+}
+
 class Monitor : public node::ObjectWrap {
     struct poll_struct {
         Persistent<Object> monitor;
@@ -163,6 +179,31 @@ NAN_METHOD(GetNodeParentBySyspath) {
     NanReturnValue(obj);
 }
 
+NAN_METHOD(GetSysattrBySyspath) {
+    NanScope();
+    struct udev_device *dev;
+
+    if(!args[0]->IsString()) {
+        NanThrowTypeError("first argument must be a string");
+        NanReturnNull();
+    }
+
+    v8::Local<v8::String> string = args[0]->ToString();
+
+    dev = udev_device_new_from_syspath(udev, *NanUtf8String(string));
+    if (dev == NULL) {
+        NanThrowError("device not found");
+        NanReturnNull();
+    }
+
+    Local<Object> obj = NanNew<Object>();
+    PushSystemAttributes(obj, dev);
+    obj->Set(NanNew<String>("syspath"), string);
+    udev_device_unref(dev);
+
+    NanReturnValue(obj);
+}
+
 static void Init(Handle<Object> target) {
     udev = udev_new();
     if (!udev) {
@@ -174,6 +215,9 @@ static void Init(Handle<Object> target) {
     target->Set(
         NanNew<String>("getNodeParentBySyspath"),
         NanNew<FunctionTemplate>(GetNodeParentBySyspath)->GetFunction());
+    target->Set(
+        NanNew<String>("getSysattrBySyspath"),
+        NanNew<FunctionTemplate>(GetSysattrBySyspath)->GetFunction());
 
     Monitor::Init(target);
 }

--- a/udev.js
+++ b/udev.js
@@ -5,6 +5,7 @@ udev.Monitor.prototype.__proto__ = EventEmitter.prototype;
 
 module.exports = {
     monitor: function() { return new udev.Monitor(); },
-    list: udev.list, 
+    list: udev.list,
     getNodeParentBySyspath: udev.getNodeParentBySyspath,
+    getSysattrBySyspath: udev.getSysattrBySyspath,
 }

--- a/udev.js
+++ b/udev.js
@@ -1,11 +1,52 @@
 var udev = require('./build/Release/udev'),
-    EventEmitter = require('events').EventEmitter;
+  EventEmitter = require('events').EventEmitter;
+
+
+var getDetailedNodeChain = function (node) {
+  var result = [], extra;
+  while (node && node.hasOwnProperty('syspath')) {
+    extra = udev.getSysattrBySyspath(node.syspath);
+    for (var key in extra) {
+      if (extra.hasOwnProperty(key)) {
+        node[key] = extra[key];
+      }
+    }
+    result.push(node);
+    node = udev.getNodeParentBySyspath(node.syspath);
+  }
+  return result;
+};
+
+
+var getNodeDetailsSummary = function (node) {
+  var result = {},
+    nodes = getDetailedNodeChain(node),
+    key;
+  while (nodes.length != 0) {
+    node = nodes.pop();
+    for (key in node) {
+      if (node.hasOwnProperty(key)) {
+        if (!result.hasOwnProperty(key)) {
+          result[key] = [];
+        }
+        result[key].push(node[key]);
+      }
+    }
+  }
+  return result;
+};
+
 
 udev.Monitor.prototype.__proto__ = EventEmitter.prototype;
 
+
 module.exports = {
-    monitor: function() { return new udev.Monitor(); },
-    list: udev.list,
-    getNodeParentBySyspath: udev.getNodeParentBySyspath,
-    getSysattrBySyspath: udev.getSysattrBySyspath,
-}
+  monitor: function () {
+    return new udev.Monitor();
+  },
+  list: udev.list,
+  getNodeParentBySyspath: udev.getNodeParentBySyspath,
+  getSysattrBySyspath: udev.getSysattrBySyspath,
+  getNodeChain: getDetailedNodeChain,
+  getNodeDetails: getNodeDetailsSummary
+};

--- a/udev.js
+++ b/udev.js
@@ -6,4 +6,5 @@ udev.Monitor.prototype.__proto__ = EventEmitter.prototype;
 module.exports = {
     monitor: function() { return new udev.Monitor(); },
     list: udev.list, 
+    getNodeParentBySyspath: udev.getNodeParentBySyspath,
 }


### PR DESCRIPTION
The extends the sparse information currently available on nodes:

* `getNodeParentBySyspath`: Returns the parent node of a node.
* `getSysattrBySyspath`: Returns additional information on a node.
* `getNodeChain`: Returns a list of a node and all its parents with extended information for each.
* `getNodeDetails`: Returns an object with lists of extended information of a node and its parents.