### PR TITLE
Update NaN dependency to build correctly on Node 5.3.0 (and others)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "udev",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Bindings to libudev",
   "main": "udev.js",
   "scripts": {
@@ -23,6 +23,6 @@
   "gypfile": true,
   "readmeFilename": "README.md",
   "dependencies": {
-    "nan": "~2.1.0"
+    "nan": "~2.2.0"
   }
 }


### PR DESCRIPTION
Current NaN correctly interfaces with newer versions of Node. Presumably it also works with older versions, though I haven't tried. (Regardless, the abstraction is on their shoulders!)