### PR TITLE
node 6 complains with `v8::ObjectTemplate::Set() with non-primitive v…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "udev",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Bindings to libudev",
   "main": "udev.js",
   "scripts": {
@@ -26,6 +26,6 @@
   "gypfile": true,
   "readmeFilename": "README.md",
   "dependencies": {
-    "nan": "~2.2.0"
+    "nan": "~2.3.0"
   }
 }


### PR DESCRIPTION
node 6 complains with `v8::ObjectTemplate::Set() with non-primitive values is deprecated` and dumps a stacktrace. Fixed in nan 2.3.0
I bumped the version to 0.4.0 as I haven't tested to make sure this change is compatible with node versions less than 6.