### PR TITLE
Fix a -Wdeprecated-declarations warning.

### DIFF
--- a/udev.cc
+++ b/udev.cc
@@ -59,7 +59,6 @@ class Monitor : public node::ObjectWrap {
         obj->Set(Nan::New<String>("syspath").ToLocalChecked(), Nan::New<String>(udev_device_get_syspath(dev)).ToLocalChecked());
         PushProperties(obj, dev);
 
-        TryCatch tc;
         Local<Function> emit = monitor->Get(Nan::New<String>("emit").ToLocalChecked()).As<Function>();
         Local<Value> emitArgs[2];
         emitArgs[0] = Nan::New<String>(udev_device_get_action(dev)).ToLocalChecked();


### PR DESCRIPTION
This patch remove the declaration as the variable is unused.

Before this PR we get:
```
  CXX(target) Release/obj.target/udev/udev.o
../udev.cc: In static member function ‘static void Monitor::on_handle_event(uv_poll_t*, int, int)’:
../udev.cc:62:18: warning: ‘v8::TryCatch::TryCatch()’ is deprecated: Use isolate version [-Wdeprecated-declarations]
         TryCatch tc;
                  ^
```

System info for the context:
```
% node --version
v6.10.3
% npm --version
5.0.3
% lsb_release -d                                                                                                                       
Description:    Ubuntu 16.04.2 LTS
```