### PR TITLE
Be more specific about the license, fixing a npm warning.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "linux"
   ],
   "author": "Henri Tuhola <henri.tuhola@gmail.com>",
-  "license": "BSD",
+  "license": "BSD-2-Clause",
   "gypfile": true,
   "readmeFilename": "README.md",
   "dependencies": {


### PR DESCRIPTION
Before this patch we get:

```
npm WARN udev@0.4.0 license should be a valid SPDX license expression
```

See https://spdx.org/licenses/ for the full list.