### PR TITLE
Subsystem filtering for the udev monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Requires node-v0.8.0, nan and libudev.
 
 ## How to Use
 
-The example below lists devices and monitors udev events and closes its monitor when receiving an add -event. The code is separately listed in `samples/howto.js`.
+The example below lists devices and monitors udev events on the ipnut subsystem until receiving an add event. The code is separately listed in `samples/howto.js`.
 
     var udev = require("udev");
 
     console.log(udev.list()); // this is a long list :)
 
-    var monitor = udev.monitor();
+    var monitor = udev.monitor("input");
     monitor.on('add', function (device) {
         console.log('added ' + device);
         monitor.close() // this closes the monitor.

--- a/samples/howto.js
+++ b/samples/howto.js
@@ -5,8 +5,8 @@ var udev = require("../udev");
 // Lists every device in the system.
 console.log(udev.list()); // this is a long list :)
 
-// Opens a monitor that closes when it receives an add -event.
-var monitor = udev.monitor();
+// Monitor events on the input subsystem until a device is added.
+var monitor = udev.monitor("input");
 monitor.on('add', function (device) {
     console.log('added ' + device);
     monitor.close() // this closes the monitor

--- a/udev.cc
+++ b/udev.cc
@@ -76,6 +76,17 @@ class Monitor : public node::ObjectWrap {
         obj->mon = udev_monitor_new_from_netlink(udev, "udev");
         obj->fd = udev_monitor_get_fd(obj->mon);
         obj->poll_handle = handle = new uv_poll_t;
+
+        if (info[0]->IsString()) {
+            v8::Local<v8::String> subsystem = info[0]->ToString();
+            int r;
+            r = udev_monitor_filter_add_match_subsystem_devtype(obj->mon,
+                    *Nan::Utf8String(subsystem), NULL);
+            if (r < 0) {
+                Nan::ThrowError("adding the subsystem filter failed");
+            }
+        }
+
         udev_monitor_enable_receiving(obj->mon);
         poll_struct* data = new poll_struct;
         //NanAssignPersistent(data->monitor, info.This());
@@ -140,7 +151,7 @@ NAN_METHOD(List) {
     // add match etc. stuff.
     if(info[0]->IsString()) {
         v8::Local<v8::String> subsystem = info[0]->ToString();
-  	    udev_enumerate_add_match_subsystem(enumerate, *Nan::Utf8String(subsystem));
+        udev_enumerate_add_match_subsystem(enumerate, *Nan::Utf8String(subsystem));
     }
     udev_enumerate_scan_devices(enumerate);
     devices = udev_enumerate_get_list_entry(enumerate);

--- a/udev.js
+++ b/udev.js
@@ -44,8 +44,8 @@ udev.Monitor.prototype.__proto__ = EventEmitter.prototype;
 
 
 module.exports = {
-  monitor: function () {
-    return new udev.Monitor();
+  monitor: function (subsystem) {
+    return new udev.Monitor(subsystem);
   },
   list: udev.list,
   getNodeParentBySyspath: udev.getNodeParentBySyspath,


### PR DESCRIPTION
When creating a new monitor, a filter can be added so that events from
only one subsystem will be seen.