### PR TITLE
Avoid segfaulting when udev_monitor_receive_device returns NULL

### DIFF
--- a/udev.cc
+++ b/udev.cc
@@ -54,6 +54,9 @@ class Monitor : public node::ObjectWrap {
         Local<Object> monitor = Nan::New(data->monitor);
         Monitor* wrapper = ObjectWrap::Unwrap<Monitor>(monitor);
         udev_device* dev = udev_monitor_receive_device(wrapper->mon);
+        if (dev == NULL) {
+                return;
+        }
 
         Local<Object> obj = Nan::New<Object>();
         obj->Set(Nan::New<String>("syspath").ToLocalChecked(), Nan::New<String>(udev_device_get_syspath(dev)).ToLocalChecked());


### PR DESCRIPTION
I am getting segfaults on `add` and `remove` events on a compute module 3.

According to the [udev_monitor_receive_device docs](https://www.freedesktop.org/software/systemd/man/udev_monitor_receive_device.html):

>On failure, NULL is returned.