### PR TITLE
fix bad udev_device_get_parent unref

### DIFF
--- a/udev.cc
+++ b/udev.cc
@@ -169,27 +169,31 @@ Napi::Value GetNodeParentBySyspath(const Napi::CallbackInfo &info) {
   }
 
   Napi::String string = info[0].ToString();
+
   udev_device_ptr dev(
       udev_device_new_from_syspath(instance.get(), string.Utf8Value().c_str()),
       &detail::unref_udev_device);
+
   if (!dev) {
     Napi::Error::New(env, "device not found").ThrowAsJavaScriptException();
     return env.Null();
   }
 
-  udev_device_ptr parentDev(udev_device_get_parent(dev.get()),
-                            &detail::unref_udev_device);
+  udev_device *parentDev = udev_device_get_parent(dev.get());
+
   if (!parentDev) {
     return env.Null();
   }
 
   Napi::Object obj = Napi::Object::New(env);
-  PushProperties(env, obj, parentDev.get());
-  const char *path = udev_device_get_syspath(parentDev.get());
+
+  PushProperties(env, obj, parentDev);
+
+  const char *path = udev_device_get_syspath(parentDev);
 
   if (!path) {
     Napi::Error::New(env, "udev returned null syspath")
-        .ThrowAsJavaScriptException();
+      .ThrowAsJavaScriptException();
     return env.Null();
   }
 


### PR DESCRIPTION
udev_device_get_parent return a pointer to the parent device. No
additional reference to this device is acquired, but the child device
owns a reference to such a parent device. On failure, NULL is returned.

unreferencing the pointer returned by udev_device_get_parent is
incorrect, and abort the program in some version of libudev due to a
failing assertion:

`Assertion 'p->n_ref > 0' failed at src/libudev/libudev-device.c:502,
function udev_device_unref. Aborting.`